### PR TITLE
0001: Slider now changes based on steps (prop value)

### DIFF
--- a/src/component/js/GraphDisplay.js
+++ b/src/component/js/GraphDisplay.js
@@ -2,6 +2,9 @@ import React from "react";
 import Slider from '@mui/material/Slider';
 import "../css/GraphDisplay.css";
 
+const STEP_SIZE = 1;
+const DEFAULT_STEP_VALUE = 0;
+
 export default class GraphDisplay extends React.Component {
     render() {
         return (
@@ -10,7 +13,14 @@ export default class GraphDisplay extends React.Component {
 
                 </div>
                 <div className="slider-container">
-                    <Slider defaultValue={30} step={10} marks min={10} max={110}/>
+                    <Slider 
+                        defaultValue={DEFAULT_STEP_VALUE} 
+                        step={STEP_SIZE} 
+                        marks 
+                        min={0} 
+                        max={this.props.steps} 
+                        disabled={this.props.steps === 0}
+                    />
                 </div>
             </div>
         );

--- a/src/component/js/MainPage.js
+++ b/src/component/js/MainPage.js
@@ -14,7 +14,7 @@ export default class MainPage extends React.Component {
     render() {
         return (
             <div className="container">
-                <GraphDisplay/>
+                <GraphDisplay steps={0}/>
                 <Options/>
             </div>
         );


### PR DESCRIPTION
Hi all! My apologies for forking again, I think my permissions are still a little wonky! 

These are the new features that I added:
- number of steps in slider is determined by 'steps' prop attribute
- slider is disabled when a steps value of 0 is passed down to it

I was debating whether I should disable the slider or hide it entirely on load/when no
steps are given, please let me know if you'd prefer the latter!